### PR TITLE
Make sudo: false explicit, as sudo otherwise depends on when the repo was added to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 cache: pip
 python:


### PR DESCRIPTION
Use explicit sudo: false, which otherwise depends on date added to Travis